### PR TITLE
Enable ADR-0086 Grid review local worker

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,7 +2,7 @@ name: Grid Review Request
 
 on:
   pull_request_target:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,23 @@
+name: Grid Review Request
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: grid-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request-grid-review:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main
+    with:
+      review-config-path: .honeydrunk-review.yaml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.honeydrunk-review.yaml
+++ b/.honeydrunk-review.yaml
@@ -1,0 +1,8 @@
+enabled: true
+runner: local-worker
+severity_floor: Suggest
+skip_paths:
+  - "**/*.Designer.cs"
+  - "**/*.g.cs"
+  - "**/generated/**"
+cost_cap_per_pr_usd: 0.00


### PR DESCRIPTION
Authorship: agent-codex
Packet: HoneyDrunkStudios/HoneyDrunk.Architecture:generated/issue-packets/active/adr-0086-pull-based-local-worker-grid-review/03-architecture-author-pull-worker.md

## Summary

- Switch this repository from the legacy OpenClaw review request path to the ADR-0086 local-worker Grid review queue.
- Add or normalize `.honeydrunk-review.yaml` for `runner: local-worker`.
- Add the safe `pull_request_target` caller that delegates to `HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main` without checking out or executing PR-head code.

## Validation

- Generated from current default branch via the GitHub API to avoid local worktree drift.
- The workflow relies on the shared Actions queue workflow for label normalization, queue comments, and review request metadata.
